### PR TITLE
Fix wrong name of the GamepadSettings in root_preferences.xml

### DIFF
--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -35,7 +35,7 @@
 
     <PreferenceCategory app:title="@string/input">
         <Preference
-            app:fragment="io.maido.m8client.settings.GamepadButtonSettings"
+            app:fragment="io.maido.m8client.settings.GamepadSettings"
             app:summary="@string/gamepad_mappings_summary"
             app:title="@string/gamepad_mappings" />
     </PreferenceCategory>


### PR DESCRIPTION
Hi, Thanks for the great application!

I found that the app will crash trying to tap the "Gamepad Mapping" on settings. After quick investigation I found that the fragment had a wrong class name, so it crash with "class name not found".

This will fix the issue and enable setting gamepad mapping again.