### PR TITLE
Fix #236

### DIFF
--- a/app/src/main/assets/config.ini
+++ b/app/src/main/assets/config.ini
@@ -28,18 +28,17 @@ key_left=80
 key_down=81
 key_right=79
 key_select=225
-key_select_alt=28
+key_select_alt=5
 key_start=44
-key_start_alt=26
+key_start_alt=4
 ; match m8.run and use Z for Option
 key_opt=29
-key_opt_alt=4
+key_opt_alt=226
 ; match m8.run and use X for Edit
 key_edit=27
 key_edit_alt=22
 key_delete=76
 key_reset=21
-
 [gamepad]
 ; these need to be the decimal value of the SDL Controller buttons.
 ; a table exists here: https://wiki.libsdl.org/SDL_GameControllerButton

--- a/app/src/main/assets/config.ini
+++ b/app/src/main/assets/config.ini
@@ -31,9 +31,11 @@ key_select=225
 key_select_alt=29
 key_start=44
 key_start_alt=27
-key_opt=226
+; match m8.run and use Z for Option
+key_opt=29
 key_opt_alt=4
-key_edit=224
+; match m8.run and use X for Edit
+key_edit=27
 key_edit_alt=22
 key_delete=76
 key_reset=21

--- a/app/src/main/assets/config.ini
+++ b/app/src/main/assets/config.ini
@@ -28,9 +28,9 @@ key_left=80
 key_down=81
 key_right=79
 key_select=225
-key_select_alt=29
+key_select_alt=28
 key_start=44
-key_start_alt=27
+key_start_alt=26
 ; match m8.run and use Z for Option
 key_opt=29
 key_opt_alt=4


### PR DESCRIPTION
This makes the default SDL scan codes match the web UX at m8.run and the keyboard mappings for https://github.com/adwuard/TrackerKB