### PR TITLE
UI work

### DIFF
--- a/app/src/main/res/layout/buttons.xml
+++ b/app/src/main/res/layout/buttons.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/buttons"
     android:layout_width="match_parent"
@@ -63,22 +62,47 @@
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true">
 
-            <ImageButton
-                android:id="@+id/option"
+            <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@null"
-                android:contentDescription="@string/option"
-                android:src="@drawable/button" />
+                android:layout_height="wrap_content">
 
-            <ImageButton
-                android:id="@+id/edit"
+                <ImageButton
+                    android:id="@+id/option"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@null"
+                    android:contentDescription="@string/option"
+                    android:src="@drawable/button" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="O"
+                    android:textSize="14sp" />
+            </FrameLayout>
+
+
+            <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@null"
-                android:contentDescription="@string/edit"
-                android:paddingHorizontal="20dp"
-                android:src="@drawable/button" />
+                android:layout_height="wrap_content">
+
+                <ImageButton
+                    android:id="@+id/edit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@null"
+                    android:contentDescription="@string/edit"
+                    android:paddingHorizontal="20dp"
+                    android:src="@drawable/button" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="E"
+                    android:textSize="14sp" />
+            </FrameLayout>
         </LinearLayout>
 
         <LinearLayout
@@ -87,22 +111,46 @@
             android:layout_alignParentEnd="true"
             android:layout_alignParentBottom="true">
 
-            <ImageButton
-                android:id="@+id/shift"
+            <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@null"
-                android:contentDescription="@string/shift"
-                android:src="@drawable/button" />
+                android:layout_height="wrap_content">
 
-            <ImageButton
-                android:id="@+id/play"
+                <ImageButton
+                    android:id="@+id/shift"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@null"
+                    android:contentDescription="@string/shift"
+                    android:src="@drawable/button" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="S"
+                    android:textSize="14sp" />
+            </FrameLayout>
+
+            <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@null"
-                android:contentDescription="@string/play"
-                android:paddingHorizontal="20dp"
-                android:src="@drawable/button" />
+                android:layout_height="wrap_content">
+
+                <ImageButton
+                    android:id="@+id/play"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@null"
+                    android:contentDescription="@string/play"
+                    android:paddingHorizontal="20dp"
+                    android:src="@drawable/button" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="P"
+                    android:textSize="14sp" />
+            </FrameLayout>
         </LinearLayout>
 
 

--- a/app/src/main/res/layout/buttons_alt.xml
+++ b/app/src/main/res/layout/buttons_alt.xml
@@ -13,25 +13,50 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="20dp"
-        android:gravity="end">
+        android:gravity="end"
+        android:paddingVertical="20dp">
 
-        <ImageButton
-            android:id="@+id/option"
+        <FrameLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@null"
-            android:contentDescription="@string/option"
-            android:src="@drawable/button" />
+            android:layout_height="wrap_content">
 
-        <ImageButton
-            android:id="@+id/edit"
+            <ImageButton
+                android:id="@+id/option"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:contentDescription="@string/option"
+                android:src="@drawable/button" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="O"
+                android:textSize="14sp" />
+        </FrameLayout>
+
+
+        <FrameLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@null"
-            android:contentDescription="@string/edit"
-            android:paddingHorizontal="20dp"
-            android:src="@drawable/button" />
+            android:layout_height="wrap_content">
+
+            <ImageButton
+                android:id="@+id/edit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:contentDescription="@string/edit"
+                android:paddingHorizontal="20dp"
+                android:src="@drawable/button" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="E"
+                android:textSize="14sp" />
+        </FrameLayout>
     </LinearLayout>
 
     <LinearLayout
@@ -78,33 +103,57 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:background="@null"
-            android:paddingHorizontal="20dp"
             android:contentDescription="@string/right"
+            android:paddingHorizontal="20dp"
             android:src="@drawable/button" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingVertical="20dp"
-        android:gravity="end|bottom">
+        android:gravity="end|bottom"
+        android:paddingVertical="20dp">
 
-        <ImageButton
-            android:id="@+id/shift"
+        <FrameLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@null"
-            android:contentDescription="@string/shift"
-            android:src="@drawable/button" />
+            android:layout_height="wrap_content">
 
-        <ImageButton
-            android:id="@+id/play"
+            <ImageButton
+                android:id="@+id/shift"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:contentDescription="@string/shift"
+                android:src="@drawable/button" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="S"
+                android:textSize="14sp" />
+        </FrameLayout>
+
+        <FrameLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@null"
-            android:contentDescription="@string/play"
-            android:paddingHorizontal="20dp"
-            android:src="@drawable/button" />
+            android:layout_height="wrap_content">
+
+            <ImageButton
+                android:id="@+id/play"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:contentDescription="@string/play"
+                android:paddingHorizontal="20dp"
+                android:src="@drawable/button" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="P"
+                android:textSize="14sp" />
+        </FrameLayout>
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -19,6 +19,19 @@
         app:layout_constraintTop_toTopOf="parent"
         app:title="M8C Settings" />
 
+    <Button
+        android:id="@+id/startButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:minWidth="100dp"
+        android:text="@string/start"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/settings_container"
+        app:layout_constraintVertical_bias="1" />
+
     <ScrollView
         android:id="@+id/settings_scroll"
         android:layout_width="match_parent"
@@ -41,18 +54,6 @@
 
             </androidx.fragment.app.FragmentContainerView>
 
-            <Button
-                android:id="@+id/startButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="20dp"
-                android:minWidth="100dp"
-                android:text="@string/start"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/settings_container"
-                app:layout_constraintVertical_bias="1" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,9 +5,13 @@
     <string name="right">Right</string>
     <string name="down">Down</string>
     <string name="option">Option</string>
+    <string name="option_char">O</string>
     <string name="edit">Edit</string>
+    <string name="edit_char">E</string>
     <string name="play">Play</string>
+    <string name="play_char">P</string>
     <string name="shift">Shift</string>
+    <string name="shift_char">S</string>
     <string name="connect_your_m8_device">Connect your M8 device!</string>
     <string name="start">Start</string>
     <string name="show_onscreen_buttons">Show onscreen buttons</string>


### PR DESCRIPTION
I moved the "Start" button to the top, as I frequently restart m8c due to audio and state issues, enabling quick bypassing of the settings screen.

I also added an option for single-letter labels on action buttons (Play, Edit, Option, Shift), aiding comprehension of keymap PDFs and faster learning of m8headless.

I reorganized preferences to leverage dependencies, disabling related options when buttons are hidden.

I kindly request these changes be considered for upstream inclusion.