### PR TITLE
Add volume boost setting

### DIFF
--- a/app/jni/src/handlers.c
+++ b/app/jni/src/handlers.c
@@ -91,6 +91,12 @@ Java_io_maido_m8client_M8SDLActivity_hintAudioInputDevice(JNIEnv *env, jobject t
 }
 
 JNIEXPORT void JNICALL
+Java_io_maido_m8client_M8SDLActivity_setAudioGain(JNIEnv *env, jobject thiz, jfloat gain) {
+    SDL_Log("Setting audio gain to %f", (double)gain);
+    audio_set_gain((float)gain);
+}
+
+JNIEXPORT void JNICALL
 Java_io_maido_m8client_M8SDLActivity_lockOrientation(JNIEnv *env, jobject thiz, jstring lock) {
     if (lock == NULL) {
         SDL_Log("Don't lock orientation");

--- a/app/src/main/kotlin/io/maido/m8client/M8SDLActivity.kt
+++ b/app/src/main/kotlin/io/maido/m8client/M8SDLActivity.kt
@@ -158,6 +158,7 @@ class M8SDLActivity : SDLActivity() {
         useDefaultAudioInput = generalPreferences.useDefaultAudioInput
         audioBuffer = generalPreferences.audioBuffer
         hintAudioDriver(generalPreferences.audioDriver)
+        setAudioGain(generalPreferences.audioGain)
         if (useDefaultAudio) {
             currentAudioDeviceId = GeneralSettings.getBestOutputDeviceId(this)
             hintAudioOutputDevice(currentAudioDeviceId)
@@ -343,6 +344,8 @@ class M8SDLActivity : SDLActivity() {
     private external fun restartAudioOutput(bufferSize: Int)
 
     private external fun hintAudioInputDevice(deviceId: Int)
+
+    private external fun setAudioGain(gain: Float)
 
     private external fun sendMidiCC(channel: Int, cc: Int, value: Int)
 

--- a/app/src/main/kotlin/io/maido/m8client/settings/GeneralSettings.kt
+++ b/app/src/main/kotlin/io/maido/m8client/settings/GeneralSettings.kt
@@ -78,6 +78,8 @@ class GeneralSettings : PreferenceFragmentCompat() {
             val idleMs = preferences.getString(context.getString(R.string.idle_ms_pref), "0")!!
             val audioBuffer =
                 preferences.getString(context.getString(R.string.audio_buffer_pref), "4096")!!
+            val audioGain =
+                preferences.getString(context.getString(R.string.audio_gain_pref), "1.0")!!.toFloat()
             val useNewLayout =
                 preferences.getBoolean(context.getString(R.string.new_button_layout_pref), false)
             val touchCcEnabled = preferences.getBoolean(context.getString(R.string.touch_cc_enabled_pref), false)
@@ -98,7 +100,8 @@ class GeneralSettings : PreferenceFragmentCompat() {
                 touchCcEnabled,
                 touchCcChannel,
                 touchCcX,
-                touchCcY
+                touchCcY,
+                audioGain
             )
         }
     }
@@ -236,5 +239,6 @@ data class GeneralPreferences(
     val touchCcEnabled: Boolean = false,
     val touchCcChannel: Int = 1,
     val touchCcX: Int = 1,
-    val touchCcY: Int = 2
+    val touchCcY: Int = 2,
+    val audioGain: Float = 1.0f
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,20 @@
         <item>4096</item>
         <item>8192</item>
     </string-array>
+    <string-array name="audio_gain_entries">
+        <item>1x (default)</item>
+        <item>1.5x</item>
+        <item>2x</item>
+        <item>3x</item>
+    </string-array>
+    <string-array name="audio_gain_values">
+        <item>1.0</item>
+        <item>1.5</item>
+        <item>2.0</item>
+        <item>3.0</item>
+    </string-array>
+    <string name="audio_gain_pref">audio_gain</string>
+    <string name="choose_audio_gain">Volume boost</string>
     <string name="use_default_audio_pref">use_default_audio</string>
     <string name="use_default_audio">Use default audio device</string>
     <string name="use_default_audio_summary">Let the system decide; follows headphones, Bluetooth, etc.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -50,6 +50,14 @@
             app:title="@string/choose_audio_buffer"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:defaultValue="1.0"
+            app:entries="@array/audio_gain_entries"
+            app:entryValues="@array/audio_gain_values"
+            app:key="@string/audio_gain_pref"
+            app:title="@string/choose_audio_gain"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/ui">


### PR DESCRIPTION
Since in headless the m8's volume control doesn't work, I've found that the volume can be too low, even on max setting. So this gives some boost so I can finally make myself deaf with m8's juicy supersaws as well.

## Summary

- Adds a **Volume boost** preference in Settings → Audio (1x / 1.5x / 2x / 3x, default 1x)
- Calls `SDL_SetAudioStreamGain()` on the SDL output stream — SDL3 supports gain > 1.0, allowing amplification past Android's hardware volume ceiling
- The M8's internal volume knob has no effect on the Android audio stream (it controls the USB audio device itself, not the SDL stream), so a software gain is the right workaround
- Gain is stored in the native layer and re-applied automatically whenever audio is restarted (device switch, reconnect)

## Test plan

- [ ] Default (1x) sounds the same as before
- [ ] 2x and 3x are noticeably louder
- [ ] Setting persists across app restarts
- [ ] Gain re-applies correctly after Bluetooth device switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)